### PR TITLE
Add auditd::audisp for managing the dispatcher on older auditd versions.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -9,6 +9,7 @@
 #### Public Classes
 
 * [`auditd`](#auditd): audit daemon
+* [`auditd::audisp`](#auditdaudisp): audit event dispatcher
 
 #### Private Classes
 
@@ -23,6 +24,7 @@
 
 ### Data types
 
+* [`Auditd::Audisp::Conf`](#auditdaudispconf): audispd.conf configuration file parameters
 * [`Auditd::Conf`](#auditdconf): auditd.conf configuration file parameters
 * [`Auditd::Plugins`](#auditdplugins): auditd plugin parameters
 * [`Auditd::Rules`](#auditdrules): auditd rule parameters
@@ -56,6 +58,7 @@ The following parameters are available in the `auditd` class:
 * [`service_name`](#service_name)
 * [`service_ensure`](#service_ensure)
 * [`service_manage`](#service_manage)
+* [`service_override`](#service_override)
 * [`plugin_dir`](#plugin_dir)
 * [`plugin_dir_mode`](#plugin_dir_mode)
 * [`plugin_dir_owner`](#plugin_dir_owner)
@@ -223,6 +226,14 @@ If the auditd service should be managed
 
 Default value: ``true``
 
+##### <a name="service_override"></a>`service_override`
+
+Data type: `Optional[String]`
+
+auditd service override content
+
+Default value: ``undef``
+
 ##### <a name="plugin_dir"></a>`plugin_dir`
 
 Data type: `Stdlib::Absolutepath`
@@ -335,6 +346,168 @@ Hash of auditd rules to set
 
 Default value: `{}`
 
+### <a name="auditdaudisp"></a>`auditd::audisp`
+
+audit event dispatcher
+
+#### Parameters
+
+The following parameters are available in the `auditd::audisp` class:
+
+* [`dir`](#dir)
+* [`mode`](#mode)
+* [`owner`](#owner)
+* [`group`](#group)
+* [`config`](#config)
+* [`config_path`](#config_path)
+* [`config_mode`](#config_mode)
+* [`config_owner`](#config_owner)
+* [`config_group`](#config_group)
+* [`package_name`](#package_name)
+* [`package_ensure`](#package_ensure)
+* [`package_manage`](#package_manage)
+* [`plugin_dir`](#plugin_dir)
+* [`plugin_dir_mode`](#plugin_dir_mode)
+* [`plugin_dir_owner`](#plugin_dir_owner)
+* [`plugin_dir_group`](#plugin_dir_group)
+* [`plugins`](#plugins)
+
+##### <a name="dir"></a>`dir`
+
+Data type: `Stdlib::Absolutepath`
+
+The auditd configuration directory path
+
+Default value: `'/etc/audisp'`
+
+##### <a name="mode"></a>`mode`
+
+Data type: `Stdlib::Filemode`
+
+The auditd configuration directory mode
+
+Default value: `'0750'`
+
+##### <a name="owner"></a>`owner`
+
+Data type: `Variant[String[1], Integer]`
+
+The auditd configuration directory owner
+
+Default value: `0`
+
+##### <a name="group"></a>`group`
+
+Data type: `Variant[String[1], Integer]`
+
+The auditd configuration directory group
+
+Default value: `0`
+
+##### <a name="config"></a>`config`
+
+Data type: `Auditd::Audisp::Conf`
+
+audispd.conf configuration hash
+
+Default value: `{}`
+
+##### <a name="config_path"></a>`config_path`
+
+Data type: `Stdlib::Absolutepath`
+
+audispd.conf file path
+
+Default value: `'/etc/audisp/audispd.conf'`
+
+##### <a name="config_mode"></a>`config_mode`
+
+Data type: `Stdlib::Filemode`
+
+audispd.conf file mode
+
+Default value: `'0600'`
+
+##### <a name="config_owner"></a>`config_owner`
+
+Data type: `Variant[String[1], Integer]`
+
+audispd.conf file owner
+
+Default value: `0`
+
+##### <a name="config_group"></a>`config_group`
+
+Data type: `Variant[String[1], Integer]`
+
+audispd.conf file group
+
+Default value: `0`
+
+##### <a name="package_name"></a>`package_name`
+
+Data type: `String[1]`
+
+The audisp plugins package name
+
+Default value: `'audispd-plugins'`
+
+##### <a name="package_ensure"></a>`package_ensure`
+
+Data type: `String`
+
+The package state to set
+
+Default value: `'installed'`
+
+##### <a name="package_manage"></a>`package_manage`
+
+Data type: `Boolean`
+
+If the audisp plugin package should be managed
+
+Default value: ``true``
+
+##### <a name="plugin_dir"></a>`plugin_dir`
+
+Data type: `Stdlib::Absolutepath`
+
+The plugin directory path to manage
+
+Default value: `'/etc/audisp/plugins.d'`
+
+##### <a name="plugin_dir_mode"></a>`plugin_dir_mode`
+
+Data type: `Stdlib::Filemode`
+
+The plugin directory mode
+
+Default value: `'0750'`
+
+##### <a name="plugin_dir_owner"></a>`plugin_dir_owner`
+
+Data type: `Variant[String[1], Integer]`
+
+The plugin directory owner
+
+Default value: `0`
+
+##### <a name="plugin_dir_group"></a>`plugin_dir_group`
+
+Data type: `Variant[String[1], Integer]`
+
+The plugin directory group
+
+Default value: `0`
+
+##### <a name="plugins"></a>`plugins`
+
+Data type: `Optional[Hash[String, Auditd::Plugins]]`
+
+Hash of audisp plugin configuration files to create
+
+Default value: `{}`
+
 ## Defined types
 
 ### <a name="auditdplugin"></a>`auditd::plugin`
@@ -351,6 +524,7 @@ The following parameters are available in the `auditd::plugin` defined type:
 * [`type`](#type)
 * [`args`](#args)
 * [`format`](#format)
+* [`plugin_type`](#plugin_type)
 * [`mode`](#mode)
 * [`owner`](#owner)
 * [`group`](#group)
@@ -373,7 +547,7 @@ Default value: `'out'`
 
 ##### <a name="path"></a>`path`
 
-Data type: `Stdlib::Absolutepath`
+Data type: `Variant[Stdlib::Absolutepath, String]`
 
 The absolute path to the plugin executable.
 
@@ -401,11 +575,19 @@ Binary or string dispatcher options.
 
 Default value: `'string'`
 
+##### <a name="plugin_type"></a>`plugin_type`
+
+Data type: `Enum['auditd', 'audisp']`
+
+The plugin type
+
+Default value: `'auditd'`
+
 ##### <a name="mode"></a>`mode`
 
 Data type: `Stdlib::Filemode`
 
-
+The file mode to apply
 
 Default value: `'0600'`
 
@@ -413,7 +595,7 @@ Default value: `'0600'`
 
 Data type: `Variant[String, Integer]`
 
-
+The file owner to set
 
 Default value: `0`
 
@@ -421,7 +603,7 @@ Default value: `0`
 
 Data type: `Variant[String, Integer]`
 
-
+The file group to set
 
 Default value: `0`
 
@@ -453,6 +635,24 @@ The rule priority order (between 1 and 100)
 Default value: `10`
 
 ## Data types
+
+### <a name="auditdaudispconf"></a>`Auditd::Audisp::Conf`
+
+audispd.conf configuration file parameters
+
+Alias of
+
+```puppet
+Struct[{
+    Optional['q_depth']         => Integer,
+    Optional['overflow_action'] => Enum['ignore', 'IGNORE', 'syslog', 'SYSLOG', 'suspend', 'SUSPEND', 'single', 'SINGLE', 'halt', 'HALT'],
+    Optional['priority_boost']  => Integer[0],
+    Optional['max_restarts']    => Integer[0],
+    Optional['name_format']     => Enum['none', 'NONE', 'hostname', 'HOSTNAME', 'fqd', 'FQD', 'numeric', 'NUMERIC', 'user', 'USER'],
+    Optional['name']            => String,
+    Optional['plugin_dir']      => Stdlib::Absolutepath,
+  }]
+```
 
 ### <a name="auditdconf"></a>`Auditd::Conf`
 
@@ -512,15 +712,16 @@ Alias of
 
 ```puppet
 Struct[{
-    Optional['active']    => Enum['yes', 'no'],
-    Optional['direction'] => Enum['in', 'out'],
-    'path'                => Stdlib::Absolutepath,
-    Optional['type']      => Enum['builtin', 'always'],
-    Optional['args']      => String,
-    Optional['format']    => Enum['binary', 'string'],
-    Optional['mode']      => Stdlib::Filemode,
-    Optional['owner']     => Variant[String, Integer],
-    Optional['group']     => Variant[String, Integer],
+    Optional['active']      => Enum['yes', 'no'],
+    Optional['direction']   => Enum['in', 'out'],
+    'path'                  => Variant[Stdlib::Absolutepath, String],
+    Optional['type']        => Enum['builtin', 'always'],
+    Optional['args']        => String,
+    Optional['format']      => Enum['binary', 'string'],
+    Optional['plugin_type'] => Enum['auditd', 'audisp'],
+    Optional['mode']        => Stdlib::Filemode,
+    Optional['owner']       => Variant[String, Integer],
+    Optional['group']       => Variant[String, Integer],
   }]
 ```
 

--- a/data/AlmaLinux-8.yaml
+++ b/data/AlmaLinux-8.yaml
@@ -7,7 +7,7 @@ auditd::config:
   local_events: 'yes'
   write_logs: 'yes'
   log_file: /var/log/audit/audit.log
-  log_group: adm
+  log_group: root
   log_format: enriched
   flush: incremental_async
   freq: 50
@@ -21,6 +21,9 @@ auditd::config:
   verify_email: 'yes'
   action_mail_acct: root
   admin_space_left: 50
+  admin_space_left_action: rotate
+  disk_full_action: syslog
+  disk_error_action: syslog
   use_libwrap: 'yes'
   tcp_listen_queue: 5
   tcp_max_per_addr: 1
@@ -47,17 +50,10 @@ auditd::plugins:
     path: /sbin/audisp-remote
     type: always
     format: string
-  audispd-zos-remote:
-    active: 'no'
-    direction: out
-    path: /sbin/audispd-zos-remote
-    type: always
-    args: /etc/audit/zos-remote.conf
-    format: string
   syslog:
     active: 'no'
     direction: out
-    path: builtin_syslog
-    type: builtin
+    path: /sbin/audisp-syslog
+    type: always
     args: LOG_INFO
     format: string

--- a/data/CentOS-7.yaml
+++ b/data/CentOS-7.yaml
@@ -1,19 +1,17 @@
 ---
-auditd::audisp::dir: /etc/audit
-auditd::audisp::config_path: /etc/audit/auditd.conf
-auditd::audisp::plugin_dir: /etc/audit/plugins.d
-
 auditd::config:
   local_events: 'yes'
   write_logs: 'yes'
   log_file: /var/log/audit/audit.log
-  log_group: adm
-  log_format: enriched
+  log_group: root
+  log_format: raw
   flush: incremental_async
   freq: 50
   max_log_file: 8
   num_logs: 5
   priority_boost: 4
+  disp_qos: lossy
+  dispatcher: /sbin/audispd
   name_format: none
   max_log_file_action: rotate
   space_left: 75
@@ -21,19 +19,26 @@ auditd::config:
   verify_email: 'yes'
   action_mail_acct: root
   admin_space_left: 50
+  admin_space_left_action: rotate
+  disk_full_action: syslog
+  disk_error_action: syslog
   use_libwrap: 'yes'
   tcp_listen_queue: 5
   tcp_max_per_addr: 1
   tcp_client_max_idle: 0
-  transport: tcp
+  enable_krb5: 'no'
   krb5_principal: auditd
   distribute_network: 'no'
-  q_depth: 400
-  overflow_action: syslog
-  max_restarts: 10
-  plugin_dir: /etc/audit/plugins.d
 
-auditd::plugins:
+auditd::audisp::config:
+  q_depth: 250
+  overflow_action: syslog
+  priority_boost: 4
+  max_restarts: 10
+  name_format: hostname
+  plugin_dir: /etc/audisp/plugins.d/
+
+auditd::audisp::plugins:
   af_unix:
     active: 'no'
     direction: out
@@ -52,12 +57,12 @@ auditd::plugins:
     direction: out
     path: /sbin/audispd-zos-remote
     type: always
-    args: /etc/audit/zos-remote.conf
+    args: /etc/audisp/zos-remote.conf
     format: string
   syslog:
     active: 'no'
     direction: out
-    path: builtin_syslog
-    type: builtin
+    path: /sbin/audisp-syslog
+    type: always
     args: LOG_INFO
     format: string

--- a/data/Debian-10.yaml
+++ b/data/Debian-10.yaml
@@ -26,3 +26,46 @@ auditd::config:
   enable_krb5: 'no'
   krb5_principal: auditd
   distribute_network: 'no'
+
+auditd::audisp::config:
+  q_depth: 250
+  overflow_action: syslog
+  priority_boost: 4
+  max_restarts: 10
+  name_format: hostname
+  plugin_dir: /etc/audisp/plugins.d/
+
+auditd::audisp::plugins:
+  af_unix:
+    active: 'no'
+    direction: out
+    path: builtin_af_unix
+    type: builtin
+    args: 0640 /var/run/audispd_events
+    format: string
+  au-prelude:
+    active: 'no'
+    direction: out
+    path: /sbin/audisp-prelude
+    type: always
+    format: string
+  au-remote:
+    active: 'no'
+    direction: out
+    path: /sbin/audisp-remote
+    type: always
+    format: string
+  audispd-zos-remote:
+    active: 'no'
+    direction: out
+    path: /sbin/audispd-zos-remote
+    type: always
+    args: /etc/audisp/zos-remote.conf
+    format: string
+  syslog:
+    active: 'no'
+    direction: out
+    path: builtin_syslog
+    type: builtin
+    args: LOG_INFO
+    format: string

--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -4,3 +4,7 @@ auditd::config:
   disp_qos: lossy
   dispatcher: /sbin/audispd
   log_group: adm
+
+auditd::audisp::dir: /etc/audisp
+auditd::audisp::config_path: /etc/audisp/audispd.conf
+auditd::audisp::plugin_dir: /etc/audisp/plugins.d

--- a/data/RedHat-7.yaml
+++ b/data/RedHat-7.yaml
@@ -1,19 +1,17 @@
 ---
-auditd::audisp::dir: /etc/audit
-auditd::audisp::config_path: /etc/audit/auditd.conf
-auditd::audisp::plugin_dir: /etc/audit/plugins.d
-
 auditd::config:
   local_events: 'yes'
   write_logs: 'yes'
   log_file: /var/log/audit/audit.log
-  log_group: adm
-  log_format: enriched
+  log_group: root
+  log_format: raw
   flush: incremental_async
   freq: 50
   max_log_file: 8
   num_logs: 5
   priority_boost: 4
+  disp_qos: lossy
+  dispatcher: /sbin/audispd
   name_format: none
   max_log_file_action: rotate
   space_left: 75
@@ -21,19 +19,26 @@ auditd::config:
   verify_email: 'yes'
   action_mail_acct: root
   admin_space_left: 50
+  admin_space_left_action: rotate
+  disk_full_action: syslog
+  disk_error_action: syslog
   use_libwrap: 'yes'
   tcp_listen_queue: 5
   tcp_max_per_addr: 1
   tcp_client_max_idle: 0
-  transport: tcp
+  enable_krb5: 'no'
   krb5_principal: auditd
   distribute_network: 'no'
-  q_depth: 400
-  overflow_action: syslog
-  max_restarts: 10
-  plugin_dir: /etc/audit/plugins.d
 
-auditd::plugins:
+auditd::audisp::config:
+  q_depth: 250
+  overflow_action: syslog
+  priority_boost: 4
+  max_restarts: 10
+  name_format: hostname
+  plugin_dir: /etc/audisp/plugins.d/
+
+auditd::audisp::plugins:
   af_unix:
     active: 'no'
     direction: out
@@ -52,12 +57,12 @@ auditd::plugins:
     direction: out
     path: /sbin/audispd-zos-remote
     type: always
-    args: /etc/audit/zos-remote.conf
+    args: /etc/audisp/zos-remote.conf
     format: string
   syslog:
     active: 'no'
     direction: out
-    path: builtin_syslog
-    type: builtin
+    path: /sbin/audisp-syslog
+    type: always
     args: LOG_INFO
     format: string

--- a/data/RedHat-8.yaml
+++ b/data/RedHat-8.yaml
@@ -7,7 +7,7 @@ auditd::config:
   local_events: 'yes'
   write_logs: 'yes'
   log_file: /var/log/audit/audit.log
-  log_group: adm
+  log_group: root
   log_format: enriched
   flush: incremental_async
   freq: 50
@@ -21,6 +21,9 @@ auditd::config:
   verify_email: 'yes'
   action_mail_acct: root
   admin_space_left: 50
+  admin_space_left_action: rotate
+  disk_full_action: syslog
+  disk_error_action: syslog
   use_libwrap: 'yes'
   tcp_listen_queue: 5
   tcp_max_per_addr: 1
@@ -47,17 +50,10 @@ auditd::plugins:
     path: /sbin/audisp-remote
     type: always
     format: string
-  audispd-zos-remote:
-    active: 'no'
-    direction: out
-    path: /sbin/audispd-zos-remote
-    type: always
-    args: /etc/audit/zos-remote.conf
-    format: string
   syslog:
     active: 'no'
     direction: out
-    path: builtin_syslog
-    type: builtin
+    path: /sbin/audisp-syslog
+    type: always
     args: LOG_INFO
     format: string

--- a/data/Rocky-8.yaml
+++ b/data/Rocky-8.yaml
@@ -7,7 +7,7 @@ auditd::config:
   local_events: 'yes'
   write_logs: 'yes'
   log_file: /var/log/audit/audit.log
-  log_group: adm
+  log_group: root
   log_format: enriched
   flush: incremental_async
   freq: 50
@@ -21,6 +21,9 @@ auditd::config:
   verify_email: 'yes'
   action_mail_acct: root
   admin_space_left: 50
+  admin_space_left_action: rotate
+  disk_full_action: syslog
+  disk_error_action: syslog
   use_libwrap: 'yes'
   tcp_listen_queue: 5
   tcp_max_per_addr: 1
@@ -47,17 +50,10 @@ auditd::plugins:
     path: /sbin/audisp-remote
     type: always
     format: string
-  audispd-zos-remote:
-    active: 'no'
-    direction: out
-    path: /sbin/audispd-zos-remote
-    type: always
-    args: /etc/audit/zos-remote.conf
-    format: string
   syslog:
     active: 'no'
     direction: out
-    path: builtin_syslog
-    type: builtin
+    path: /sbin/audisp-syslog
+    type: always
     args: LOG_INFO
     format: string

--- a/data/Scientific-7.yaml
+++ b/data/Scientific-7.yaml
@@ -1,19 +1,17 @@
 ---
-auditd::audisp::dir: /etc/audit
-auditd::audisp::config_path: /etc/audit/auditd.conf
-auditd::audisp::plugin_dir: /etc/audit/plugins.d
-
 auditd::config:
   local_events: 'yes'
   write_logs: 'yes'
   log_file: /var/log/audit/audit.log
-  log_group: adm
-  log_format: enriched
+  log_group: root
+  log_format: raw
   flush: incremental_async
   freq: 50
   max_log_file: 8
   num_logs: 5
   priority_boost: 4
+  disp_qos: lossy
+  dispatcher: /sbin/audispd
   name_format: none
   max_log_file_action: rotate
   space_left: 75
@@ -21,19 +19,26 @@ auditd::config:
   verify_email: 'yes'
   action_mail_acct: root
   admin_space_left: 50
+  admin_space_left_action: rotate
+  disk_full_action: syslog
+  disk_error_action: syslog
   use_libwrap: 'yes'
   tcp_listen_queue: 5
   tcp_max_per_addr: 1
   tcp_client_max_idle: 0
-  transport: tcp
+  enable_krb5: 'no'
   krb5_principal: auditd
   distribute_network: 'no'
-  q_depth: 400
-  overflow_action: syslog
-  max_restarts: 10
-  plugin_dir: /etc/audit/plugins.d
 
-auditd::plugins:
+auditd::audisp::config:
+  q_depth: 250
+  overflow_action: syslog
+  priority_boost: 4
+  max_restarts: 10
+  name_format: hostname
+  plugin_dir: /etc/audisp/plugins.d/
+
+auditd::audisp::plugins:
   af_unix:
     active: 'no'
     direction: out
@@ -52,12 +57,12 @@ auditd::plugins:
     direction: out
     path: /sbin/audispd-zos-remote
     type: always
-    args: /etc/audit/zos-remote.conf
+    args: /etc/audisp/zos-remote.conf
     format: string
   syslog:
     active: 'no'
     direction: out
-    path: builtin_syslog
-    type: builtin
+    path: /sbin/audisp-syslog
+    type: always
     args: LOG_INFO
     format: string

--- a/data/Ubuntu-18.04.yaml
+++ b/data/Ubuntu-18.04.yaml
@@ -26,3 +26,46 @@ auditd::config:
   enable_krb5: 'no'
   krb5_principal: auditd
   distribute_network: 'no'
+
+auditd::audisp::config:
+  q_depth: 250
+  overflow_action: syslog
+  priority_boost: 4
+  max_restarts: 10
+  name_format: hostname
+  plugin_dir: /etc/audisp/plugins.d/
+
+auditd::audisp::plugins:
+  af_unix:
+    active: 'no'
+    direction: out
+    path: builtin_af_unix
+    type: builtin
+    args: 0640 /var/run/audispd_events
+    format: string
+  au-prelude:
+    active: 'no'
+    direction: out
+    path: /sbin/audisp-prelude
+    type: always
+    format: string
+  au-remote:
+    active: 'no'
+    direction: out
+    path: /sbin/audisp-remote
+    type: always
+    format: string
+  audispd-zos-remote:
+    active: 'no'
+    direction: out
+    path: /sbin/audispd-zos-remote
+    type: always
+    args: /etc/audisp/zos-remote.conf
+    format: string
+  syslog:
+    active: 'no'
+    direction: out
+    path: builtin_syslog
+    type: builtin
+    args: LOG_INFO
+    format: string

--- a/data/Ubuntu-20.04.yaml
+++ b/data/Ubuntu-20.04.yaml
@@ -26,3 +26,46 @@ auditd::config:
   enable_krb5: 'no'
   krb5_principal: auditd
   distribute_network: 'no'
+
+auditd::audisp::config:
+  q_depth: 250
+  overflow_action: syslog
+  priority_boost: 4
+  max_restarts: 10
+  name_format: hostname
+  plugin_dir: /etc/audisp/plugins.d/
+
+auditd::audisp::plugins:
+  af_unix:
+    active: 'no'
+    direction: out
+    path: builtin_af_unix
+    type: builtin
+    args: 0640 /var/run/audispd_events
+    format: string
+  au-prelude:
+    active: 'no'
+    direction: out
+    path: /sbin/audisp-prelude
+    type: always
+    format: string
+  au-remote:
+    active: 'no'
+    direction: out
+    path: /sbin/audisp-remote
+    type: always
+    format: string
+  audispd-zos-remote:
+    active: 'no'
+    direction: out
+    path: /sbin/audispd-zos-remote
+    type: always
+    args: /etc/audisp/zos-remote.conf
+    format: string
+  syslog:
+    active: 'no'
+    direction: out
+    path: builtin_syslog
+    type: builtin
+    args: LOG_INFO
+    format: string

--- a/data/Ubuntu-22.04.yaml
+++ b/data/Ubuntu-22.04.yaml
@@ -21,6 +21,9 @@ auditd::config:
   verify_email: 'yes'
   action_mail_acct: root
   admin_space_left: 50
+  admin_space_left_action: email
+  disk_full_action: rotate
+  disk_error_action: syslog
   use_libwrap: 'yes'
   tcp_listen_queue: 5
   tcp_max_per_addr: 1
@@ -28,10 +31,11 @@ auditd::config:
   transport: tcp
   krb5_principal: auditd
   distribute_network: 'no'
-  q_depth: 400
+  q_depth: 1200
   overflow_action: syslog
   max_restarts: 10
   plugin_dir: /etc/audit/plugins.d
+  end_of_event_timeout: 2
 
 auditd::plugins:
   af_unix:

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,41 @@
 ---
+# Daemon configuration
+auditd::config:
+  local_events: 'yes'
+  log_file: /var/log/auditd.log
+  write_logs: 'yes'
+  log_format: raw
+  log_group: root
+  priority_boost: 4
+  flush: incremental
+  freq: 20
+  num_logs: 4
+  name_format: none
+  max_log_file: 25
+  max_log_file_action: rotate
+  verify_email: 'no'
+  action_mail_acct: root
+  space_left: 75
+  space_left_action: email
+  admin_space_left: 50
+  admin_space_left_action: email
+  disk_full_action: syslog
+  disk_error_action: syslog
+  tcp_listen_queue: 5
+  tcp_client_max_idle: 0
+  enable_krb5: 'no'
+  krb5_principal: auditd
+  distribute_network: 'no'
+
+# Dispatcher configuration
+auditd::audisp::config:
+  q_depth: 250
+  overflow_action: syslog
+  priority_boost: 4
+  max_restarts: 10
+  name_format: hostname
+  plugin_dir: /etc/audisp/plugins.d/
+
 # Package
 auditd::package_ensure: installed
 auditd::package_manage: true
@@ -7,6 +44,10 @@ auditd::package_manage: true
 auditd::service_enable: true
 auditd::service_ensure: running
 auditd::service_manage: true
+auditd::service_override: |-
+  [Unit]
+  RefuseManualStart=no
+  RefuseManualStop=no
 
 # Root audit directory
 auditd::path: /etc/audit
@@ -43,30 +84,19 @@ auditd::config_mode: '0600'
 auditd::config_owner: 0
 auditd::config_group: 0
 
-# Daemon configuration
-auditd::config:
-  local_events: 'yes'
-  log_file: /var/log/auditd.log
-  write_logs: 'yes'
-  log_format: raw
-  log_group: root
-  priority_boost: 4
-  flush: incremental
-  freq: 20
-  num_logs: 4
-  name_format: none
-  max_log_file: 25
-  max_log_file_action: rotate
-  verify_email: 'no'
-  action_mail_acct: root
-  space_left: 75
-  space_left_action: email
-  admin_space_left: 50
-  admin_space_left_action: email
-  disk_full_action: rotate
-  disk_error_action: syslog
-  tcp_listen_queue: 5
-  tcp_client_max_idle: 0
-  enable_krb5: 'no'
-  krb5_principal: auditd
-  distribute_network: 'no'
+# Audit Dispatcher
+auditd::audisp::dir: /etc/audisp
+auditd::audisp::mode: '0750'
+auditd::audisp::owner: 0
+auditd::audisp::group: 0
+auditd::audisp::config_path: /etc/audisp/audispd.conf
+auditd::audisp::config_mode: '0600'
+auditd::audisp::config_owner: 0
+auditd::audisp::config_group: 0
+auditd::audisp::package_name: audispd-plugins
+auditd::audisp::package_ensure: installed
+auditd::audisp::package_manage: true
+auditd::audisp::plugin_dir: /etc/audisp/plugins.d
+auditd::audisp::plugin_dir_mode: '0750'
+auditd::audisp::plugin_dir_owner: 0
+auditd::audisp::plugin_dir_group: 0

--- a/manifests/audisp.pp
+++ b/manifests/audisp.pp
@@ -1,0 +1,123 @@
+# @summary audit event dispatcher
+#
+# @param dir
+#   The auditd configuration directory path
+#
+# @param mode
+#   The auditd configuration directory mode
+#
+# @param owner
+#   The auditd configuration directory owner
+#
+# @param group
+#   The auditd configuration directory group
+#
+# @param config
+#   audispd.conf configuration hash
+#
+# @param config_path
+#   audispd.conf file path
+#
+# @param config_mode
+#   audispd.conf file mode
+#
+# @param config_owner
+#   audispd.conf file owner
+#
+# @param config_group
+#   audispd.conf file group
+#
+# @param package_name
+#   The audisp plugins package name
+#
+# @param package_ensure
+#   The package state to set
+#
+# @param package_manage
+#   If the audisp plugin package should be managed
+#
+# @param plugin_dir
+#   The plugin directory path to manage
+#
+# @param plugin_dir_mode
+#   The plugin directory mode
+#
+# @param plugin_dir_owner
+#   The plugin directory owner
+#
+# @param plugin_dir_group
+#   The plugin directory group
+#
+# @param plugins
+#    Hash of audisp plugin configuration files to create
+#
+# @author Dan Gibbs <dev@dangibbs.co.uk>
+#
+class auditd::audisp (
+  Stdlib::Absolutepath $dir                        = '/etc/audisp',
+  Stdlib::Filemode $mode                           = '0750',
+  Variant[String[1], Integer] $owner               = 0,
+  Variant[String[1], Integer] $group               = 0,
+  Auditd::Audisp::Conf $config                     = {},
+  Stdlib::Absolutepath $config_path                = '/etc/audisp/audispd.conf',
+  Stdlib::Filemode $config_mode                    = '0600',
+  Variant[String[1], Integer] $config_owner        = 0,
+  Variant[String[1], Integer] $config_group        = 0,
+  String[1] $package_name                          = 'audispd-plugins',
+  String $package_ensure                           = 'installed',
+  Boolean $package_manage                          = true,
+  Stdlib::Absolutepath $plugin_dir                 = '/etc/audisp/plugins.d',
+  Stdlib::Filemode $plugin_dir_mode                = '0750',
+  Variant[String[1], Integer] $plugin_dir_owner    = 0,
+  Variant[String[1], Integer] $plugin_dir_group    = 0,
+  Optional[Hash[String, Auditd::Plugins]] $plugins = {},
+) inherits auditd {
+
+  if $package_manage {
+    package { $package_name:
+      ensure => $package_ensure,
+    }
+  }
+
+  if $dir != $auditd::dir {
+    file { $dir:
+      ensure => directory,
+      owner  => $owner,
+      group  => $group,
+      mode   => $mode,
+    }
+  }
+
+  if $plugin_dir != $auditd::plugin_dir {
+    file { $plugin_dir:
+      ensure => directory,
+      owner  => $plugin_dir_owner,
+      group  => $plugin_dir_group,
+      mode   => $plugin_dir_mode,
+    }
+  }
+
+  if $config_path != $auditd::config_path {
+    file { $config_path:
+      ensure  => file,
+      owner   => $config_owner,
+      group   => $config_group,
+      mode    => $config_mode,
+      content => epp('auditd/audisp.conf.epp', {
+        config => $config,
+      }),
+    }
+  }
+
+  file { '/sbin/audispd':
+    ensure => file,
+    mode   => '0750',
+  }
+
+  $plugins.each |$name, $parameters| {
+    auditd::plugin { $name:
+      *           => $parameters,
+      plugin_type => 'audisp',
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,9 @@
 # @param service_manage
 #   If the auditd service should be managed
 #
+# @param service_override
+#   auditd service override content
+#
 # @param plugin_dir
 #   The plugin directory path to manage
 #
@@ -121,6 +124,7 @@ class auditd (
   String[1] $service_name                          = 'auditd',
   Stdlib::Ensure::Service $service_ensure          = 'running',
   Boolean $service_manage                          = true,
+  Optional[String] $service_override               = undef,
   Stdlib::Absolutepath $plugin_dir                 = '/etc/audit/plugins.d',
   Stdlib::Filemode $plugin_dir_mode                = '0750',
   Variant[String[1], Integer] $plugin_dir_owner    = 0,

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -20,24 +20,42 @@
 # @param format
 #   Binary or string dispatcher options.
 #
+# @param plugin_type
+#   The plugin type
+#
+# @param mode
+#   The file mode to apply
+#
+# @param owner
+#   The file owner to set
+#
+# @param group
+#   The file group to set
+#
 define auditd::plugin (
+  Variant[Stdlib::Absolutepath, String] $path,
   Enum['yes', 'no'] $active = 'yes',
   Enum['in', 'out'] $direction = 'out',
-  Stdlib::Absolutepath $path,
   Enum['builtin', 'always'] $type = 'always',
   Optional[String] $args = undef,
   Enum['binary', 'string'] $format = 'string',
+  Enum['auditd', 'audisp'] $plugin_type = 'auditd',
   Stdlib::Filemode $mode = '0600',
   Variant[String, Integer] $owner = 0,
   Variant[String, Integer] $group = 0,
 ) {
 
-  file { "auditd-plugin-${name}.conf":
+  $plugin_path = ($plugin_type == 'audisp') ? {
+    true    => $auditd::audisp::plugin_dir,
+    default => $auditd::plugin_dir,
+  }
+
+  file { "auditd-${plugin_type}-plugin-${name}.conf":
     ensure  => file,
-    path    => "${auditd::plugin_dir}/${name}.conf",
+    path    => "${plugin_path}/${name}.conf",
     mode    => $mode,
-    owner   => $auditd::plugin_dir_owner,
-    group   => $auditd::plugin_dir_group,
+    owner   => $owner,
+    group   => $group,
     content => epp('auditd/plugin.conf.epp', {
       active    => $active,
       direction => $direction,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,6 +6,23 @@ class auditd::service {
   assert_private()
 
   if $auditd::service_manage {
+    if $auditd::service_override {
+      file { '/etc/systemd/system/auditd.service.d':
+        ensure => directory,
+        owner  => 0,
+        group  => 0,
+        mode   => '0750',
+      }
+
+      file { '/etc/systemd/system/auditd.service.d/override.conf':
+        ensure  => file,
+        owner   => 0,
+        group   => 0,
+        mode    => '0640',
+        content => $auditd::service_override,
+      }
+    }
+
     service { $auditd::service_name:
       ensure     => $auditd::service_ensure,
       enable     => $auditd::service_enable,

--- a/spec/acceptance/audisp_spec.rb
+++ b/spec/acceptance/audisp_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper_acceptance'
+
+describe 'include auditd::audisp' do
+  audit_v2 = ['centos7', 'debian10', 'redhat7', 'scientific7', 'ubuntu20', 'ubuntu18']
+  audit_v3 = ['almalinux8', 'debian11', 'redhat8', 'rocky8', 'ubuntu22']
+  test_os = [os[:family], os[:release].to_i].join('')
+
+  # @note: auditd doesn't work well with containers. local_events is disabled
+  # for the service to run and allow rudimentary tests to be performed.
+  pp = <<-MANIFEST
+    $config = lookup('auditd::config')
+
+    class { 'auditd':
+      config => deep_merge($config, {
+        local_events => 'no',
+      }),
+    }
+
+    include auditd::audisp
+  MANIFEST
+
+  it 'applies idempotently' do
+    idempotent_apply(pp)
+  end
+
+  if audit_v2.include?(test_os)
+    describe file('/etc/audisp/') do
+      it { is_expected.to exist }
+      it { is_expected.to be_directory }
+      it { is_expected.to be_mode 7_50 }
+      it { is_expected.to be_owned_by 'root' }
+    end
+
+    describe file('/etc/audisp/plugins.d/') do
+      it { is_expected.to exist }
+      it { is_expected.to be_directory }
+      it { is_expected.to be_mode 7_50 }
+      it { is_expected.to be_owned_by 'root' }
+    end
+  end
+
+  if audit_v3.include?(test_os)
+    describe file('/etc/audisp/') do
+      it { is_expected.not_to exist }
+    end
+
+    describe file('/etc/audisp/plugins.d/') do
+      it { is_expected.not_to exist }
+    end
+  end
+
+  describe file('/sbin/audispd') do
+    it { is_expected.to exist }
+    it { is_expected.to be_file }
+    it { is_expected.to be_mode 7_50 }
+    it { is_expected.to be_owned_by 'root' }
+  end
+end

--- a/spec/classes/audisp_spec.rb
+++ b/spec/classes/audisp_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'auditd::audisp' do
+  context 'supported operating systems' do
+    audit_v2 = ['CentOS7', 'Debian10', 'RedHat7', 'Scientific7', 'Ubuntu20.04', 'Ubuntu18.04']
+    audit_v3 = ['AlmaLinux8', 'Debian11', 'RedHat8', 'Rocky8', 'Ubuntu22.04']
+
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) { facts }
+
+        test_os = [facts[:os]['name'], facts[:os]['release']['major']].join('')
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('auditd::audisp') }
+        it { is_expected.to contain_package('audispd-plugins') }
+
+        if audit_v2.include?(test_os)
+          it { is_expected.to contain_file('/etc/audisp/').with_ensure('directory') }
+          it { is_expected.to contain_file('/etc/audisp/plugins.d').with_ensure('directory') }
+          it { is_expected.to contain_file('/etc/audisp/audispd.conf') }
+          it {
+            is_expected.to contain_file('auditd-audisp-plugin-syslog.conf').with(
+              path: '/etc/audisp/plugins.d/syslog.conf',
+            )
+          }
+        end
+
+        if audit_v3.include?(test_os)
+          it { is_expected.not_to contain_file('/etc/audisp/').with_ensure('directory') }
+          it { is_expected.not_to contain_file('/etc/audisp/plugins.d').with_ensure('directory') }
+          it { is_expected.not_to contain_file('/etc/audisp/audispd.conf') }
+          it { is_expected.not_to contain_file('auditd-audisp-plugin-syslog.conf') }
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,9 +2,14 @@ require 'spec_helper'
 
 describe 'auditd' do
   context 'supported operating systems' do
+    audit_v2 = ['CentOS7', 'Debian10', 'RedHat7', 'Scientific7', 'Ubuntu20.04', 'Ubuntu18.04']
+    audit_v3 = ['AlmaLinux8', 'Debian11', 'RedHat8', 'Rocky8', 'Ubuntu22.04']
+
     on_supported_os.each do |os, facts|
       context "on #{os}" do
         let(:facts) { facts }
+
+        test_os = [facts[:os]['name'], facts[:os]['release']['major']].join('')
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_class('auditd') }
@@ -35,6 +40,14 @@ describe 'auditd' do
         it { is_expected.to contain_concat('/etc/audit/rules.d/audit.rules') }
         it { is_expected.to contain_concat__fragment('auditd_rules_begin') }
         it { is_expected.to contain_concat__fragment('auditd_rules_end') }
+
+        if audit_v2.include?(test_os)
+          it { is_expected.not_to contain_file('auditd-auditd-plugin-syslog.conf') }
+        end
+
+        if audit_v3.include?(test_os)
+          it { is_expected.to contain_file('auditd-auditd-plugin-syslog.conf') }
+        end
 
         context 'documentation example' do
           let(:params) do

--- a/spec/classes/plugin_spec.rb
+++ b/spec/classes/plugin_spec.rb
@@ -22,7 +22,7 @@ describe 'auditd::plugin', type: :define do
 
           it { is_expected.to compile }
           it {
-            is_expected.to contain_file('auditd-plugin-clickhouse.conf').with(
+            is_expected.to contain_file('auditd-auditd-plugin-clickhouse.conf').with(
               'ensure' => 'file',
               'path'   => '/etc/audit/plugins.d/clickhouse.conf',
               'owner'  => 0,

--- a/templates/audisp.conf.epp
+++ b/templates/audisp.conf.epp
@@ -1,0 +1,7 @@
+<%- | Auditd::Audisp::Conf $config,
+| -%>
+# THIS FILE IS MANAGED BY PUPPET
+
+<% $config.each |$key, $value| { -%>
+<%= $key %> = <%= $value %>
+<% } -%>

--- a/types/audisp/conf.pp
+++ b/types/audisp/conf.pp
@@ -1,0 +1,12 @@
+# audispd.conf configuration file parameters
+type Auditd::Audisp::Conf = Struct[
+  {
+    Optional['q_depth']         => Integer,
+    Optional['overflow_action'] => Enum['ignore', 'IGNORE', 'syslog', 'SYSLOG', 'suspend', 'SUSPEND', 'single', 'SINGLE', 'halt', 'HALT'],
+    Optional['priority_boost']  => Integer[0],
+    Optional['max_restarts']    => Integer[0],
+    Optional['name_format']     => Enum['none', 'NONE', 'hostname', 'HOSTNAME', 'fqd', 'FQD', 'numeric', 'NUMERIC', 'user', 'USER'],
+    Optional['name']            => String,
+    Optional['plugin_dir']      => Stdlib::Absolutepath,
+  }
+]

--- a/types/plugins.pp
+++ b/types/plugins.pp
@@ -1,14 +1,15 @@
 # auditd plugin parameters
 type Auditd::Plugins = Struct[
   {
-    Optional['active']    => Enum['yes', 'no'],
-    Optional['direction'] => Enum['in', 'out'],
-    'path'                => Stdlib::Absolutepath,
-    Optional['type']      => Enum['builtin', 'always'],
-    Optional['args']      => String,
-    Optional['format']    => Enum['binary', 'string'],
-    Optional['mode']      => Stdlib::Filemode,
-    Optional['owner']     => Variant[String, Integer],
-    Optional['group']     => Variant[String, Integer],
+    Optional['active']      => Enum['yes', 'no'],
+    Optional['direction']   => Enum['in', 'out'],
+    'path'                  => Variant[Stdlib::Absolutepath, String],
+    Optional['type']        => Enum['builtin', 'always'],
+    Optional['args']        => String,
+    Optional['format']      => Enum['binary', 'string'],
+    Optional['plugin_type'] => Enum['auditd', 'audisp'],
+    Optional['mode']        => Stdlib::Filemode,
+    Optional['owner']       => Variant[String, Integer],
+    Optional['group']       => Variant[String, Integer],
   }
 ]


### PR DESCRIPTION
Add default audisp configuration and plugins. Add default configuration for RedHat family distributions.