### PR TITLE
Add Ubuntu 22.04 to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -28,6 +28,7 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
+        "22.04",
         "20.04",
         "18.04"
       ]

--- a/provision.yaml
+++ b/provision.yaml
@@ -8,5 +8,6 @@ default:
     - 'litmusimage/debian:11'
     - 'litmusimage/rockylinux:8'
     - 'litmusimage/scientificlinux:7'
+    - 'litmusimage/ubuntu:22.04'
     - 'litmusimage/ubuntu:20.04'
     - 'litmusimage/ubuntu:18.04'


### PR DESCRIPTION
Ubuntu 22.04 is missing in module metadata. This PR adds it to metadata.json and provision.yaml
Unit tests and litmus tests didn't show errors locally, hoping for the best ;)
