### PR TITLE
Extend range of order parameter to 1000

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -628,9 +628,9 @@ Default value: `''`
 
 ##### <a name="order"></a>`order`
 
-Data type: `Integer[1, 100]`
+Data type: `Integer[1, 1000]`
 
-The rule priority order (between 1 and 100)
+The rule priority order (between 1 and 1000)
 
 Default value: `10`
 
@@ -734,7 +734,7 @@ Alias of
 ```puppet
 Struct[{
     Optional['content'] => String,
-    Optional['order']   => Integer[1, 99],
+    Optional['order']   => Integer[1, 999],
   }]
 ```
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -49,7 +49,7 @@ class auditd::config {
 
   concat::fragment { 'auditd_rules_end':
     target  => $auditd::rules_file,
-    order   => '99',
+    order   => '999',
     content => epp('auditd/audit-rules-end.fragment.epp', {
         immutable => $auditd::immutable,
     }),

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -6,11 +6,11 @@
 #   The rule content
 #
 # @param order
-#   The rule priority order (between 1 and 100)
+#   The rule priority order (between 1 and 1000)
 #
 define auditd::rule (
   Optional[String] $content = undef,
-  Integer[1, 100]  $order = 10,
+  Integer[1, 1000] $order = 10,
 ) {
   $rule_content = ($content == undef or $content == '') ? {
     true    => sprintf("%s\n\n", $name),

--- a/types/rules.pp
+++ b/types/rules.pp
@@ -2,6 +2,6 @@
 type Auditd::Rules = Struct[
   {
     Optional['content'] => String,
-    Optional['order']   => Integer[1, 99],
+    Optional['order']   => Integer[1, 999],
   }
 ]


### PR DESCRIPTION
When dealing with larger numbers of audit rules, a little more headroom in the range numbers is practical.
Therefore this pull requests extends the range from 100 to 1000.