### PR TITLE
Make override.conf world readable

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,7 +18,7 @@ class auditd::service {
         ensure  => file,
         owner   => 0,
         group   => 0,
-        mode    => '0640',
+        mode    => '0644',
         content => $auditd::service_override,
       }
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -244,7 +244,7 @@ describe 'auditd' do
               'ensure'  => 'file',
               'owner'   => 0,
               'group'   => 0,
-              'mode'    => '0640',
+              'mode'    => '0644',
               'content' => 'testing',
             )
           }


### PR DESCRIPTION
Systemd generates a warning message:
Configuration file /etc/systemd/system/auditd.service.d/override.conf is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.